### PR TITLE
For osx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,23 +22,26 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${LIBMANABU_INCLUDE_DIRS})
 
 if(MSYS)
-	if(EXISTS ${PROJECT_SOURCE_DIR}/opt/boost)
-		set(BOOST_ROOT ${PROJECT_SOURCE_DIR}/opt/boost/)
-	elseif(EXISTS ${PROJECT_SOURCE_DIR}/../boost)
-		set(BOOST_ROOT ${PROJECT_SOURCE_DIR}/../boost/)
-	endif()
-	include_directories(AFTER /mingw64/include/)
-	link_directories(AFTER /mingw64/lib/)
+  if(EXISTS ${PROJECT_SOURCE_DIR}/opt/boost)
+    set(BOOST_ROOT ${PROJECT_SOURCE_DIR}/opt/boost/)
+  elseif(EXISTS ${PROJECT_SOURCE_DIR}/../boost)
+    set(BOOST_ROOT ${PROJECT_SOURCE_DIR}/../boost/)
+  endif()
+  include_directories(AFTER /mingw64/include/)
+  link_directories(AFTER /mingw64/lib/)
 endif(MSYS)
+
+set(CURL_LIBRARY "-lcurl")
 
 # Generate dynamic library
 find_package(Boost REQUIRED
-	system
-	filesystem
-	date_time
+  system
+  filesystem
+  date_time
 )
 find_package(OpenSSL)
 find_package(CURL)
+find_package(msgpack)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -48,63 +51,63 @@ set(LIB_NAME manabu)
 
 #set(LIBMANABU_DYNAMIC_LIB_TARGET manabu)
 set(LIBMANABU_CXX_FILES
-	${PROJECT_SOURCE_DIR}/src/manabu.cpp
-	${PROJECT_SOURCE_DIR}/src/manabu/transactor.cpp
-	${PROJECT_SOURCE_DIR}/src/manabu/authenticator.cpp
-	${PROJECT_SOURCE_DIR}/src/manabu/student.cpp
+  ${PROJECT_SOURCE_DIR}/src/manabu.cpp
+  ${PROJECT_SOURCE_DIR}/src/manabu/transactor.cpp
+  ${PROJECT_SOURCE_DIR}/src/manabu/authenticator.cpp
+  ${PROJECT_SOURCE_DIR}/src/manabu/student.cpp
 )
 
 set(LIBMANABU_HEADER_FILES
-	${PROJECT_SOURCE_DIR}/include/manabu.h
-	${PROJECT_SOURCE_DIR}/include/manabu/version.h
-	${PROJECT_SOURCE_DIR}/include/manabu/transactor.h
-	${PROJECT_SOURCE_DIR}/include/manabu/authenticator.h
-	${PROJECT_SOURCE_DIR}/include/manabu/student.h
+  ${PROJECT_SOURCE_DIR}/include/manabu.h
+  ${PROJECT_SOURCE_DIR}/include/manabu/version.h
+  ${PROJECT_SOURCE_DIR}/include/manabu/transactor.h
+  ${PROJECT_SOURCE_DIR}/include/manabu/authenticator.h
+  ${PROJECT_SOURCE_DIR}/include/manabu/student.h
 )
 
 set(LIBMANABU_LINK_LIBRARIES
-	${Boost_FILESYSTEM_LIBRARY}
-	${Boost_SYSTEM_LIBRARY}
-	${Boost_DATE_TIME_LIBRARY}
-	${OPENSSL_LIBRARIES}
-	${CURL_LIBRARIES}
-	msgpackc
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
+  ${Boost_DATE_TIME_LIBRARY}
+  ${OPENSSL_LIBRARIES}
+  ${CURL_LIBRARIES}
+  msgpackc
 )
 
 # Generate dynamic library
 add_library(manabu SHARED ${LIBMANABU_CXX_FILES})
 target_link_libraries(manabu ${LIBMANABU_LINK_LIBRARIES})
 target_include_directories(manabu
-	PUBLIC
-	$<INSTALL_INTERFACE:include>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PUBLIC
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 set_target_properties(manabu
-	PROPERTIES
-	POSITION_INDEPENDENT_CODE TRUE
-	OUTPUT_NAME ${LIB_NAME}
-	#PUBLIC_HEADER "${LIBMANABU_HEADER_FILES}"
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE TRUE
+  OUTPUT_NAME ${LIB_NAME}
+  #PUBLIC_HEADER "${LIBMANABU_HEADER_FILES}"
 )
 
 # Generate static library
 add_library(manabu_static ${LIBMANABU_CXX_FILES})
 target_link_libraries(manabu_static ${LIBMANABU_LINK_LIBRARIES})
 target_include_directories(manabu_static
-	PUBLIC
-	$<INSTALL_INTERFACE:include>
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PUBLIC
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 set_target_properties(manabu_static
-	PROPERTIES
-	POSITION_INDEPENDENT_CODE TRUE
-	OUTPUT_NAME ${LIB_NAME}
-	#PUBLIC_HEADER ${LIBMANABU_HEADER_FILES}
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE TRUE
+  OUTPUT_NAME ${LIB_NAME}
+  #PUBLIC_HEADER ${LIBMANABU_HEADER_FILES}
 )
 
 # Specs
 if(${BUILD_TESTS})
-	add_subdirectory(${PROJECT_SOURCE_DIR}/spec)
-	enable_testing()
+  add_subdirectory(${PROJECT_SOURCE_DIR}/spec)
+  enable_testing()
 endif(${BUILD_TESTS})
 
 # Install Headers
@@ -116,19 +119,18 @@ install(
 
 # Install Libs
 install(
-	TARGETS manabu manabu_static
-	EXPORT ManabuConfig
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib
-	#PUBLIC_HEADER DESTINATION include
+  TARGETS manabu manabu_static
+  EXPORT ManabuConfig
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  #PUBLIC_HEADER DESTINATION include
 )
 export(TARGETS
     manabu manabu_static
-	FILE "${CMAKE_CURRENT_BINARY_DIR}/ManabuConfig.cmake"
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/ManabuConfig.cmake"
 )
 include(GNUInstallDirs)
 install(EXPORT
-	ManabuConfig
-	DESTINATION "${CMAKE_INSTALL_DATADIR}/manabu/cmake"
+  ManabuConfig
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/manabu/cmake"
 )
-

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 libmanabu - The Manabu client library for GAKU Engine
 =====================================================
-libmanabu is a client library to interface with GAKU Engine written in C++, with interfaces for 
-C, Java, Python and PHP (*coming soon*). For native Ruby interfaces use the native 
+libmanabu is a client library to interface with GAKU Engine written in C++, with interfaces for
+C, Java, Python and PHP (*coming soon*). For native Ruby interfaces use the native
 [Manabu](https://github.com/GAKUEngine/manabu) client.
 
 Building
 ========
-libmanabu requires CMake, the Boost development libraries and headers, OpenSSL development 
+libmanabu requires CMake, the Boost development libraries and headers, OpenSSL development
 libraries and headers, msgpack-c, and possibly a few other tools depending on your system.  
-  
+
 *System specific preparation guides are listed below.*  
-  
+
 After cloning the repository, you can build libmanabu with the following standard CMake build steps:
 
 ```sh
@@ -23,17 +23,17 @@ make
 
 This will build the libmanabu dynamic library (and specs).
 
-If you wish to build libmanabu without building specs/tests then invoke cmake with 
+If you wish to build libmanabu without building specs/tests then invoke cmake with
 -DBUILD_TESTS=OFF, like this: ```cmake -DBUILD_TESTS=OFF```.
-  
+
 System specific preparation notes follow:
 
 Linux Build Notes
 -----------------
-There are no particular build notes for Linux other than that you will need to install 
+There are no particular build notes for Linux other than that you will need to install
 CMake, Boost development libraries, OpenSSL development libraries, and msgpack-c.
 
-On Ubuntu or Debian based systems you can generally install all of the required packages 
+On Ubuntu or Debian based systems you can generally install all of the required packages
 with:
 ```sh
 sudo apt-get install cmake g++ libboost-all-dev libssl-dev libmsgpack-dev
@@ -42,15 +42,15 @@ sudo apt-get install cmake g++ libboost-all-dev libssl-dev libmsgpack-dev
 
 Windows Build Notes
 -------------------
-We recommend you compile on MSYS2 on Windows. If you already have MSYS2, make sure you are 
-up to date by running ```pacman -Syu```. You likely already have build tools installed, 
-but just in case you may want to run: 
+We recommend you compile on MSYS2 on Windows. If you already have MSYS2, make sure you are
+up to date by running ```pacman -Syu```. You likely already have build tools installed,
+but just in case you may want to run:
 ```pacman -S mingw-w64-x86_64-toolchain base-devel cmake gcc```.
-You'll need the development libraries for Boost, CURL, and OpenSSL. You can do most of this 
-with the following command: 
+You'll need the development libraries for Boost, CURL, and OpenSSL. You can do most of this
+with the following command:
 ```pacman -S openssl openssl-devel libcurl libcurl-devel mingw-w64-x86_64-msgpack-c```
-Note that we didn't install Boost - at the time of this writing the Boost distribution 
-available in MSYS2 is missing several components we need. The best solution is to 
+Note that we didn't install Boost - at the time of this writing the Boost distribution
+available in MSYS2 is missing several components we need. The best solution is to
 compile Boost yourself. For the impatient:
 
 ```sh
@@ -62,20 +62,20 @@ cd boost
 ./b2 headers
 ```
 
-There's a more detailed guide available on the Boost website. _A pre-compiled Boost 
+There's a more detailed guide available on the Boost website. _A pre-compiled Boost
 distribution may work, but we have yet to try it._
 !NOTE! Cloning and compiling Boost can take a *very* long time.
-  
-CMake will check for opt/boost and ../boost - if you have boost in another location 
-you'll need to specify the BOOST_ROOT or BOOST_INCLUDEDIR and BOOST_LIBDIR attributes 
+
+CMake will check for opt/boost and ../boost - if you have boost in another location
+you'll need to specify the BOOST_ROOT or BOOST_INCLUDEDIR and BOOST_LIBDIR attributes
 when you call the cmake command.
 
 
 OS X Build Notes
 ----------------
-If you are using a package management tool like HomeBrew you can get up and running with 
-libmanabu fairly quickly. Just make sure you have the required libraries and tools 
-installed: CMake, Boost, OpenSSL/libssl, msgpack-c. You can install these quickly with 
+If you are using a package management tool like HomeBrew you can get up and running with
+libmanabu fairly quickly. Just make sure you have the required libraries and tools
+installed: CMake, Boost, OpenSSL/libssl, msgpack-c. You can install these quickly with
 ```brew install cmake boost openssl msgpack```.
 
 Testing
@@ -83,13 +83,13 @@ Testing
 After building libmanabu with cmake, start up a gaku testing container instance with:
 
 ```sh
-gaku contianer start
+gaku container start
 gaku container testing
 ```
 
 Then, run the specs built during the make process:
 ```sh
-./spec/libmanabu_spec --log-level=all
+./build/bin/libmanabu_spec --log_level=all
 ```
 
 License & Contribution
@@ -101,10 +101,10 @@ This software is dual licensed under the GNU GPL version 3 and the AGPL version 
 The full text of these licenses can be found here:  
 [GPL](https://gnu.org/licenses/gpl.html) [AGPL](https://gnu.org/licenses/agpl.html)  
 
-When submitting code, patches, or pull requests to official GAKU Engine repositories you agree to 
-transfer copyright to your code to the GAKU Engine project. This is to prevent an external party 
-from controlling code incorporated into GAKU Engine in such a way as to influence the development 
-or sub-licensing of GAKU Engine. 
+When submitting code, patches, or pull requests to official GAKU Engine repositories you agree to
+transfer copyright to your code to the GAKU Engine project. This is to prevent an external party
+from controlling code incorporated into GAKU Engine in such a way as to influence the development
+or sub-licensing of GAKU Engine.
 
 Alternative licenses can be granted upon consultation.  
 Please contact info@gakuengine.com for details.


### PR DESCRIPTION
- msgpack.hppがないと言われたのでfind_package(msgpack)を追加した
- libcurl.soでエラーが出たのでset(CURL_LIBRARY "-lcurl")を追加した
- readmeのtypoなど修正
（他、エディタが勝手にインデントを修正）

現在のPRの状態で```cmake ..```を行うと
```
Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing: OPENSSL_INCLUDE_DIR)
```
が出ますが、```cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..```のように指定してもしなくてもmakeの結果は変わりませんでした。
とはいえ、今後がどうなるかは不明です。